### PR TITLE
Fix: c_parser ignored scopes with nameless inline struct

### DIFF
--- a/tests/test_cstruct.py
+++ b/tests/test_cstruct.py
@@ -75,10 +75,12 @@ class MBR(cstruct.CStruct):
 class Dummy(cstruct.CStruct):
     __byte_order__ = cstruct.LITTLE_ENDIAN
     __def__ = """
+        struct {
             struct {
+              int i;
+            } s;
             char c;
             char vc[10];
-            int i;
             int vi[10];
             long long l;
             long vl[10];
@@ -210,6 +212,7 @@ def test_inline():
 
 def test_dummy():
     dummy = Dummy()
+
     dummy.c = b'A'
     dummy.vc = b'ABCDEFGHIJ'
     dummy.i = 123456


### PR DESCRIPTION
The `parse_type` function would continue looking for tokens to complete its type even when the last token was a `{` and a new scope was created. This would mean that the following resulted in an exception as the read c_type was `struct { int` instead of simply `struct {`

```
__struct__ = """
  struct {
    int i;
  } s;
"""
```

This merge fixes that issue by ignoring all following tokens in `parse_type` if the last one opened a new scope.

Signed-off-by: Sophie Tyalie <dev@flowerpot.me>