### PR TITLE
Enum parsing

### DIFF
--- a/cstruct/__init__.py
+++ b/cstruct/__init__.py
@@ -43,6 +43,7 @@ from .abstract import CStructMeta, AbstractCStruct
 from .cstruct import CStruct
 from .c_parser import parse_def
 from .mem_cstruct import MemCStruct
+from .cenum import CEnum
 
 __all__ = [
     'LITTLE_ENDIAN',

--- a/cstruct/__init__.py
+++ b/cstruct/__init__.py
@@ -41,7 +41,7 @@ from .base import (
 )
 from .abstract import CStructMeta, AbstractCStruct
 from .cstruct import CStruct
-from .c_parser import parse_def
+from .c_parser import parse_struct_def
 from .mem_cstruct import MemCStruct
 from .cenum import CEnum
 
@@ -151,7 +151,7 @@ def parse(
     """
     if __cls__ is None:
         __cls__ = CStruct
-    cls_def = parse_def(__struct__, __cls__=__cls__, **kargs)
+    cls_def = parse_struct_def(__struct__, __cls__=__cls__, **kargs)
     if cls_def is None:
         return None
     else:

--- a/cstruct/abstract.py
+++ b/cstruct/abstract.py
@@ -267,9 +267,9 @@ class CEnumMeta(EnumMeta):
         def __setitem__(self, key: str, value: Any) -> None:
             env = None
             if key == "__enum__":
-                env = parse_enum(value, self["__qualname__"])
+                env = parse_enum(value)
             elif key == "__def__":
-                env = parse_enum_def(value, self["__qualname__"])
+                env = parse_enum_def(value)
 
             if env is not None:
                 # register the enum constants in the object namespace,

--- a/cstruct/abstract.py
+++ b/cstruct/abstract.py
@@ -291,7 +291,8 @@ class CEnumMeta(EnumMeta):
 
         if len(inst) > 0:
             if "__size__" not in classdict:
-                raise CEnumException("__size__ not specified. Cannot derive size as it is architecture dependent")
+                inst.__size__ = DEFAULT_ENUM_SIZE
+                print(f"Warning: __size__ not specified for enum {cls}. Will default to {DEFAULT_ENUM_SIZE} bytes")
             if not classdict.get("__anonymous__", False):
                 ENUMS[cls] = inst
         return inst
@@ -320,13 +321,15 @@ class AbstractCEnum(IntEnum, metaclass=CEnumMeta):
         Args:
             __enum__: Definition of the enum in C syntax
             __name__: Name of the new Enum. If empty, a name based on the __enum__ hash is generated
+            __size__: Number of bytes that the enum should be read as
 
         Returns:
             cls: A new class mapping the definition
         """
 
         cls_kargs: Dict[str, Any] = dict(kargs)
-        cls_kargs['__size__'] = DEFAULT_ENUM_SIZE if __size__ is None else __size__
+        if __size__ is not None:
+            cls_kargs['__size__'] = __size__
 
         if isinstance(__enum__, (str, Tokens)):
             cls_kargs.update(parse_enum_def(__enum__, __cls__=cls, **cls_kargs))

--- a/cstruct/base.py
+++ b/cstruct/base.py
@@ -101,3 +101,4 @@ ENUM_SIZE_TO_C_TYPE: Dict[int, str] = {
 }
 
 CHAR_ZERO = bytes('\0', 'ascii')
+DEFAULT_ENUM_SIZE = 4

--- a/cstruct/base.py
+++ b/cstruct/base.py
@@ -25,7 +25,7 @@
 from typing import Any, Dict, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .abstract import AbstractCStruct
+    from .abstract import AbstractCStruct, AbstractCEnum
 
 __all__ = [
     'LITTLE_ENDIAN',
@@ -47,6 +47,8 @@ NATIVE_ORDER = '@'
 "Native order, size & alignment"
 
 STRUCTS: Dict[str, Type["AbstractCStruct"]] = {}
+
+ENUMS: Dict[str, Type["AbstractCEnum"]] = {}
 
 DEFINES: Dict[str, Any] = {}
 

--- a/cstruct/base.py
+++ b/cstruct/base.py
@@ -93,4 +93,11 @@ C_TYPE_TO_FORMAT: Dict[str, str] = {
     'uint64': 'Q',
 }
 
+ENUM_SIZE_TO_C_TYPE: Dict[int, str] = {
+    1: 'uint8',
+    2: 'uint16',
+    4: 'uint32',
+    8: 'uint64'
+}
+
 CHAR_ZERO = bytes('\0', 'ascii')

--- a/cstruct/c_parser.py
+++ b/cstruct/c_parser.py
@@ -171,7 +171,6 @@ def parse_struct_def(
 
 def parse_enum_def(
     __def__: Union[str, Tokens],
-    __cls__: Type["AbstractCEnum"],
     **kargs: Any
 ) -> Optional[Dict[str, Any]]:
     # naive C enum parsing
@@ -188,16 +187,15 @@ def parse_enum_def(
     vtype = tokens.pop()
     if tokens.get() == '{':  # named enum
         tokens.pop()
-        return parse_enum(tokens, __cls__=__cls__)
+        return parse_enum(tokens)
     elif vtype == '{':
-        return parse_enum(tokens, __cls__=__cls__)
+        return parse_enum(tokens)
     else:
         raise ParserError(f"{vtype} definition expected")
 
 
 def parse_enum(
     __enum__: Union[str, Tokens],
-    __cls__: Type['AbstractCEnum'],
     **kargs: Any
 ) -> Optional[Dict[str, Any]]:
     constants: Dict[str, int] = OrderedDict()

--- a/cstruct/c_parser.py
+++ b/cstruct/c_parser.py
@@ -232,13 +232,12 @@ def parse_enum(
         name = tokens.pop()
 
         next_token = tokens.pop()
-        print(name, next_token)
         if next_token in {",", "}"}:  # enum-constant without explicit value
             if len(constants) == 0:
                 value = 0
             else:
                 value = next(reversed(constants.values())) + 1
-        elif next_token == "=":
+        elif next_token == "=":  # enum-constant with explicit value
             exp_elems = []
             next_token = tokens.pop()
             while next_token not in {",", "}"}:
@@ -256,9 +255,6 @@ def parse_enum(
                 value = c_eval(int_expr)
             except (ValueError, TypeError):
                 value = int(int_expr)
-
-            if next_token == "}":
-                break
         else:
             raise ParserError(f"{__enum__} is not a valid enum expression")
 

--- a/cstruct/c_parser.py
+++ b/cstruct/c_parser.py
@@ -25,7 +25,7 @@
 import re
 from collections import OrderedDict
 from typing import Union, Optional, Any, Dict, Type, TYPE_CHECKING
-from .base import DEFINES, TYPEDEFS, STRUCTS
+from .base import DEFINES, ENUMS, TYPEDEFS, STRUCTS
 from .field import calculate_padding, Kind, FieldType
 from .c_expr import c_eval
 from .exceptions import CStructException, ParserError
@@ -76,9 +76,9 @@ def parse_type(tokens: Tokens, __cls__: Type['AbstractCStruct'], byte_order: Opt
         raise ParserError("Parsing error")
     c_type = tokens.pop()
     # signed/unsigned/struct
-    if c_type in ['signed', 'unsigned', 'struct', 'union'] and len(tokens) > 1:
+    if c_type in ['signed', 'unsigned', 'struct', 'union', 'enum'] and len(tokens) > 1:
         c_type = c_type + " " + tokens.pop()
-    
+
     vlen = 1
     flexible_array = False
 
@@ -136,6 +136,13 @@ def parse_type(tokens: Tokens, __cls__: Type['AbstractCStruct'], byte_order: Opt
                 ref = STRUCTS[tail]
             except KeyError:
                 raise ParserError("Unknow {} {}".format(c_type, tail))
+    elif c_type.startswith('enum'):
+        c_type, tail = c_type.split(' ', 1)
+        kind = Kind.ENUM
+        try:
+            ref = ENUMS[tail]
+        except KeyError:
+            raise ParserError(f"Unknown '{c_type}' '{tail}'")
     else:  # other types
         kind = Kind.NATIVE
         ref = None

--- a/cstruct/c_parser.py
+++ b/cstruct/c_parser.py
@@ -220,7 +220,8 @@ def parse_enum(
         name = tokens.pop()
 
         next_token = tokens.pop()
-        if next_token == ",":  # enum-constant without explicit value
+        print(name, next_token)
+        if next_token in {",", "}"}:  # enum-constant without explicit value
             if len(constants) == 0:
                 value = 0
             else:

--- a/cstruct/cenum.py
+++ b/cstruct/cenum.py
@@ -1,0 +1,4 @@
+from .abstract import AbstractCEnum
+
+class CEnum(AbstractCEnum):
+  ...

--- a/cstruct/exceptions.py
+++ b/cstruct/exceptions.py
@@ -23,11 +23,14 @@
 #
 
 __all__ = [
+    "CEnumException",
     "CStructException",
     "ParserError",
     "EvalError",
 ]
 
+class CEnumException(Exception):
+    pass
 
 class CStructException(Exception):
     pass

--- a/cstruct/field.py
+++ b/cstruct/field.py
@@ -193,7 +193,7 @@ class FieldType(object):
                 raise ParserError("Unknow type {}".format(self.c_type))
         elif self.is_enum:
             try:
-                return C_TYPE_TO_FORMAT[ENUM_SIZE_TO_C_TYPE[len(self.ref)]]
+                return C_TYPE_TO_FORMAT[ENUM_SIZE_TO_C_TYPE[self.ref.size]]
             except KeyError:
                 raise ParserError(f"Enum has invalid size. Needs to be in {ENUM_SIZE_TO_C_TYPE.keys()}")
         else:

--- a/tests/test_cenum.py
+++ b/tests/test_cenum.py
@@ -1,0 +1,17 @@
+from cstruct import CEnum
+
+class Dummy(CEnum):
+  __enum__ = """
+    A,
+    B,
+    C = 2,
+    D = 5 + 7,
+    E = 2
+  """
+
+def test_dummy():
+  assert Dummy.A == 0
+  assert Dummy.B == 1
+  assert Dummy.C == 2
+  assert Dummy.D == 12
+  assert Dummy.E == 2


### PR DESCRIPTION
This merge would implement extensive enum support in python-cstruct. Named, unnamed, inline, ... enum definitions are possible with this. All enums are subclasses from Python `enum.IntEnum` and can be used as such without any further thought, they just contain an additional `.parse` and `.size` method / property.

One big issue I've hit upon is that I'm unsure about the underlying data type of enums / how they are stored in a buffer. This seems to be pretty much compiler and environment defined. I've used the `__size__` parameter that is exposed through the `.size` property in order to state how many bytes the enum will take. This will default to 4 bytes if not further specified. I'm also assuming a signed case.
There is a bit of contradicting information out there on what exactly the underlying data type of an enum is, I'm not fully sure what the best way forward is from here.
- https://gcc.gnu.org/legacy-ml/gcc-patches/2000-07/msg00993.html
- https://stackoverflow.com/a/159308

### Examples
Possible `__def__` for an MemCStruct
```c
struct {
  enum Type_A a;  // externally defined using CEnum
  enum Type_B {A, B, C} b;
  enum {A, B, C} c;
}
```

There is also a `cstruct.CEnum` class with which one can easily define enums like the following
```python
class Type_A(cstruct.CEnum):
  __size__ = 2
  __enum__ = """
    A,
    B,
    C = 5,
    D,
    E = 7 + #SOME_DEFINE
  """

# this is a nice gimmick that works, but wasn't really planned to be supported
class Type_C(cstruct.CEnum):
  A = 0,
  B = 1,
  C = 2,
  D = 3
```
