### PR TITLE
exclude tests from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ Convert C struct definitions into Python classes with methods for serializing/de
     author_email='andrea.bonomi@gmail.com',
     url='http://github.com/andreax79/python-cstruct',
     license='MIT',
-    packages=find_packages(exclude=['ez_setup', 'examples']),
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=True,
     install_requires=[


### PR DESCRIPTION
Do not install `tests` as a top-level package -- such a package name is bound to collide with other packages, and for this reason no package should be installing files there.